### PR TITLE
Fix redmine version for render_project_jump_box

### DIFF
--- a/lib/application_helper_patch.rb
+++ b/lib/application_helper_patch.rb
@@ -12,7 +12,7 @@ module ApplicationHelperPatch
   module InstanceMethods
     def render_project_jump_box_with_responsive
       return unless User.current.logged?
-      if Redmine::VERSION::MAJOR >= 2
+      if Redmine::VERSION::MAJOR >= 3
         projects = User.current.projects.active.select(:id, :name, :identifier, :lft, :rgt).to_a
       else
         projects = User.current.memberships.collect(&:project).compact.select(&:active?).uniq


### PR DESCRIPTION
`User.current.projects.active.select` is used since redmine [3.0.0](https://github.com/redmine/redmine/blob/3.0.0/app/helpers/application_helper.rb#L330). Redmine [2.6.9](https://github.com/redmine/redmine/blob/2.6.9/app/helpers/application_helper.rb#L337) still use `User.current.memberships.collect`.
